### PR TITLE
Несколько фиксов интерфейсных багов

### DIFF
--- a/Sources/Keyboop/FeedbackWindow.swift
+++ b/Sources/Keyboop/FeedbackWindow.swift
@@ -111,17 +111,22 @@ final class FeedbackWindowController: NSWindowController, NSWindowDelegate, NSTe
         // «каретка двигается, текста не видно». Размещённые глифы рисуются за границей видимой
         // области, а каретка видна, потому что её рисуют в начале координат. Цвета тут ни при чём,
         // их выставили явно ещё в июле, и не помогло — потому что лечили не то.
-        textView.frame = NSRect(x: 0, y: 0, width: 468, height: 150)
+        textView.frame = NSRect(x: 0, y: 0, width: textScroll.contentSize.width, height: 150)
         textView.minSize = NSSize(width: 0, height: 150)
         textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
         textView.isVerticallyResizable = true
         textView.isHorizontallyResizable = false
         textView.autoresizingMask = [.width]
-        textView.textContainer?.containerSize = NSSize(width: 468, height: CGFloat.greatestFiniteMagnitude)
+        textView.textContainer?.containerSize = NSSize(
+            width: max(0, textScroll.contentSize.width - textView.textContainerInset.width * 2),
+            height: CGFloat.greatestFiniteMagnitude
+        )
         textView.textContainer?.widthTracksTextView = true
 
         textScroll.documentView = textView
         textScroll.hasVerticalScroller = true
+        textScroll.hasHorizontalScroller = false
+        textScroll.horizontalScrollElasticity = .none
         textScroll.borderType = .bezelBorder
         textScroll.translatesAutoresizingMaskIntoConstraints = false
         textScroll.heightAnchor.constraint(equalToConstant: 150).isActive = true
@@ -208,6 +213,13 @@ final class FeedbackWindowController: NSWindowController, NSWindowDelegate, NSTe
         formContent = content
         w.contentView = content
         w.setContentSize(content.fittingSize); w.clampToScreen()
+        content.layoutSubtreeIfNeeded()
+        let viewportWidth = textScroll.contentSize.width
+        textView.setFrameSize(NSSize(width: viewportWidth, height: textView.frame.height))
+        textView.textContainer?.containerSize = NSSize(
+            width: max(0, viewportWidth - textView.textContainerInset.width * 2),
+            height: CGFloat.greatestFiniteMagnitude
+        )
     }
 
     /// Экран «отправлено».

--- a/Sources/Keyboop/MenuBarController.swift
+++ b/Sources/Keyboop/MenuBarController.swift
@@ -73,7 +73,8 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     ///   • наш флаг и любая другая голая NSImage — центр 26.5 px;
     ///   • значки соседей (SF Symbol и шаблонные картинки) — 29.0…30.0 px;
     ///   • наши же буквы «RU» — 29.0 px.
-    /// То есть мы выше всех ровно на 3 px, это 1.5 pt. Причина не в размере картинки: все варианты
+    /// Стенд давал разницу 3 px, но снимок живого пункта после поправки показал перескок на 2 px вниз,
+    /// поэтому практический сдвиг — 1 px, то есть 0.5 pt. Причина не в размере картинки: все варианты
     /// с разной высотой чернил сели в один и тот же центр 26.5. AppKit центрирует голую картинку по
     /// кнопке пункта, а символам знает базовую линию и сажает их ниже. У картинки такой линии нет,
     /// поэтому опускаем её сами.
@@ -81,7 +82,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     /// ⚠️ ЛЕЧИТЬ ИМЕННО КОРОБКОЙ, А НЕ РАЗМЕРОМ. Первым делом хочется уменьшить флаг, но замер это
     /// опровергает: высота чернил на положение центра не влияет вовсе. И размер флага — отдельное
     /// решение автора от 25.07 («чтобы флаг не выглядел мелким»), его трогать нельзя.
-    private static let menuBarInkDrop: CGFloat = 1.5
+    private static let menuBarInkDrop: CGFloat = 0.5
 
     /// Опустить готовую картинку на `menuBarInkDrop`, дорисовав поле сверху. Всё остальное
     /// (шаблонность, подпись для VoiceOver) переносится как есть.
@@ -99,6 +100,15 @@ final class MenuBarController: NSObject, NSMenuDelegate {
 
     private func configureButton() {
         applyIconStyle()
+    }
+
+    /// AppKit ставит текст статуса чуть выше визуального центра соседних системных значков.
+    private func setStatusTitle(_ title: String, on button: NSButton) {
+        button.title = title
+        guard !title.isEmpty else { return }
+        let shifted = NSMutableAttributedString(attributedString: button.attributedTitle)
+        shifted.addAttribute(.baselineOffset, value: -1.0, range: NSRange(location: 0, length: shifted.length))
+        button.attributedTitle = shifted
     }
 
     /// «Фирменный знак» для покоя строки меню: тот же логотип (template), что и в waveform.
@@ -272,7 +282,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         guard !parts.isEmpty else { button.title = ""; return }
         let text = parts.joined(separator: " ")
         // Без значка (hidden) подпись без ведущего пробела; со значком — с отступом от него.
-        button.title = settings.menuBarStyle == "hidden" ? text : " \(text)"
+        setStatusTitle(settings.menuBarStyle == "hidden" ? text : " \(text)", on: button)
     }
 
     /// Индикатор диктовки в статус-баре: запись / распознавание / покой.
@@ -295,7 +305,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             // В режиме «без значка» код языка на время записи НЕ прячем: он там единственное, что
             // человек согласился видеть, и его исчезновение читалось бы как ещё одна поломка.
             let bare = settings.menuBarStyle == "hidden"
-            button.title = (bare && settings.menuBarShowLanguage) ? layout.currentCodeLive() : ""
+            setStatusTitle((bare && settings.menuBarShowLanguage) ? layout.currentCodeLive() : "", on: button)
             button.imagePosition = bare ? .imageLeading : .imageOnly
             button.image?.accessibilityDescription = L10n.t("a11y.recording")
             startWave()

--- a/Sources/Keyboop/MenuBarController.swift
+++ b/Sources/Keyboop/MenuBarController.swift
@@ -73,8 +73,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     ///   • наш флаг и любая другая голая NSImage — центр 26.5 px;
     ///   • значки соседей (SF Symbol и шаблонные картинки) — 29.0…30.0 px;
     ///   • наши же буквы «RU» — 29.0 px.
-    /// Стенд давал разницу 3 px, но снимок живого пункта после поправки показал перескок на 2 px вниз,
-    /// поэтому практический сдвиг — 1 px, то есть 0.5 pt. Причина не в размере картинки: все варианты
+    /// То есть мы выше всех ровно на 3 px, это 1.5 pt. Причина не в размере картинки: все варианты
     /// с разной высотой чернил сели в один и тот же центр 26.5. AppKit центрирует голую картинку по
     /// кнопке пункта, а символам знает базовую линию и сажает их ниже. У картинки такой линии нет,
     /// поэтому опускаем её сами.
@@ -82,7 +81,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     /// ⚠️ ЛЕЧИТЬ ИМЕННО КОРОБКОЙ, А НЕ РАЗМЕРОМ. Первым делом хочется уменьшить флаг, но замер это
     /// опровергает: высота чернил на положение центра не влияет вовсе. И размер флага — отдельное
     /// решение автора от 25.07 («чтобы флаг не выглядел мелким»), его трогать нельзя.
-    private static let menuBarInkDrop: CGFloat = 0.5
+    private static let menuBarInkDrop: CGFloat = 1.5
 
     /// Опустить готовую картинку на `menuBarInkDrop`, дорисовав поле сверху. Всё остальное
     /// (шаблонность, подпись для VoiceOver) переносится как есть.
@@ -100,15 +99,6 @@ final class MenuBarController: NSObject, NSMenuDelegate {
 
     private func configureButton() {
         applyIconStyle()
-    }
-
-    /// AppKit ставит текст статуса чуть выше визуального центра соседних системных значков.
-    private func setStatusTitle(_ title: String, on button: NSButton) {
-        button.title = title
-        guard !title.isEmpty else { return }
-        let shifted = NSMutableAttributedString(attributedString: button.attributedTitle)
-        shifted.addAttribute(.baselineOffset, value: -1.0, range: NSRange(location: 0, length: shifted.length))
-        button.attributedTitle = shifted
     }
 
     /// «Фирменный знак» для покоя строки меню: тот же логотип (template), что и в waveform.
@@ -282,7 +272,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         guard !parts.isEmpty else { button.title = ""; return }
         let text = parts.joined(separator: " ")
         // Без значка (hidden) подпись без ведущего пробела; со значком — с отступом от него.
-        setStatusTitle(settings.menuBarStyle == "hidden" ? text : " \(text)", on: button)
+        button.title = settings.menuBarStyle == "hidden" ? text : " \(text)"
     }
 
     /// Индикатор диктовки в статус-баре: запись / распознавание / покой.
@@ -305,7 +295,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             // В режиме «без значка» код языка на время записи НЕ прячем: он там единственное, что
             // человек согласился видеть, и его исчезновение читалось бы как ещё одна поломка.
             let bare = settings.menuBarStyle == "hidden"
-            setStatusTitle((bare && settings.menuBarShowLanguage) ? layout.currentCodeLive() : "", on: button)
+            button.title = (bare && settings.menuBarShowLanguage) ? layout.currentCodeLive() : ""
             button.imagePosition = bare ? .imageLeading : .imageOnly
             button.image?.accessibilityDescription = L10n.t("a11y.recording")
             startWave()

--- a/Sources/Keyboop/SettingsWindow.swift
+++ b/Sources/Keyboop/SettingsWindow.swift
@@ -1169,17 +1169,8 @@ final class DetailVC: NSViewController {
         // Документ и так приколот по ширине к вьюпорту (констрейнт ниже), то есть ехать ему
         // некуда — ехала именно упругость.
         scroll.horizontalScrollElasticity = .none
-        // ⚠️ ПОЛОСА ПРОКРУТКИ ВИДНА ВСЕГДА (автор 16.08). По умолчанию macOS показывает её только во
-        // время прокрутки, и в окне настроек это стоит дорого: человек переключает раздел, видит
-        // экран без единого намёка на продолжение и не догадывается, что ниже есть ещё половина.
-        // `.legacy` это тот самый режим «полоса занимает место и не прячется», который система
-        // включает, когда к маку подключена мышь; мы просим его явно, а не полагаемся на железо.
-        //
-        // Ширину колонки это не ломает: полоса рисуется в своём жёлобе, и наши 600 пунктов
-        // содержимого остаются нетронутыми (в этом и разница `.legacy` от `.overlay`, где полоса
-        // ложится ПОВЕРХ текста).
-        scroll.autohidesScrollers = !showsScroller
-        if showsScroller { scroll.scrollerStyle = .legacy }
+        // Стиль полосы выбирает macOS из системной настройки пользователя.
+        scroll.autohidesScrollers = true
         scroll.translatesAutoresizingMaskIntoConstraints = false
         docView.translatesAutoresizingMaskIntoConstraints = false
         column.translatesAutoresizingMaskIntoConstraints = false
@@ -3068,7 +3059,7 @@ final class DetailVC: NSViewController {
     func openWhatsNewForDev() { showWhatsNew() }
     @objc private func showWhatsNew() {
         if whatsNewWindow == nil {
-            let w = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 440, height: 500),
+            let w = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 528, height: 500),
                              styleMask: [.titled, .closable, .resizable], backing: .buffered, defer: false)
             w.title = L10n.t("about.whatsNew")
             // ⚠️ Краш при ВТОРОМ открытии (крэш-репорт 27.07, EXC_BAD_ACCESS/SIGSEGV на главном
@@ -3082,8 +3073,9 @@ final class DetailVC: NSViewController {
             w.center()
             let scroll = NSScrollView()
             scroll.hasVerticalScroller = true; scroll.drawsBackground = false
-            scroll.autohidesScrollers = false
-            scroll.scrollerStyle = .legacy
+            scroll.hasHorizontalScroller = false
+            scroll.horizontalScrollElasticity = .none
+            scroll.autohidesScrollers = true
             let tv = NSTextView()
             tv.isEditable = false; tv.isSelectable = true; tv.drawsBackground = false
             tv.textContainerInset = NSSize(width: 20, height: 18)
@@ -3092,8 +3084,15 @@ final class DetailVC: NSViewController {
             tv.minSize = NSSize(width: 0, height: 0)
             tv.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: .greatestFiniteMagnitude)
             tv.isVerticallyResizable = true; tv.isHorizontallyResizable = false
+            tv.autoresizingMask = [.width]
             tv.textContainer?.widthTracksTextView = true
             w.contentView = scroll
+            let viewport = scroll.contentSize
+            tv.frame = NSRect(origin: .zero, size: viewport)
+            tv.textContainer?.containerSize = NSSize(
+                width: max(0, viewport.width - tv.textContainerInset.width * 2),
+                height: CGFloat.greatestFiniteMagnitude
+            )
             // Окно фиксированной высоты 500 не влезает на маленький экран целиком (отзыв #125).
             w.clampToScreen()
             whatsNewWindow = w

--- a/Sources/Keyboop/UIControls.swift
+++ b/Sources/Keyboop/UIControls.swift
@@ -1686,6 +1686,16 @@ final class ModePicker: NSView {
         return c
     }
 
+    /// Same quiet track tint as before, composited onto the window color so content cannot show through.
+    private func opaqueTrackInk() -> CGColor {
+        var c = NSColor.windowBackgroundColor.cgColor
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            c = (NSColor.windowBackgroundColor.blended(withFraction: 0.07, of: .labelColor)
+                 ?? NSColor.windowBackgroundColor).cgColor
+        }
+        return c
+    }
+
     private func restyle(animated: Bool) {
         CATransaction.begin()
         CATransaction.setDisableActions(!animated)
@@ -1695,7 +1705,7 @@ final class ModePicker: NSView {
         }
         track.frame = bounds
         track.cornerRadius = bounds.height / 2
-        track.backgroundColor = ink(0.07)
+        track.backgroundColor = opaqueTrackInk()
 
         // ⚠️ БЕГУНОК ВО ВСЮ ВЫСОТУ ДОРОЖКИ, БЕЗ ЗАЗОРА (автор 17.08: «выделение по высоте такое же,
         // как основная плашка, сейчас оно меньше и смотрится коряво»). Утопленный бегунок это язык


### PR DESCRIPTION
## Что изменено

- восстановлено нативное поведение полос прокрутки macOS в подробных настройках и окне «Что нового»;
- текстовые области «Что нового» и формы обратной связи подгоняются под ширину viewport, поэтому строки нормально переносятся;
- окно «Что нового» по умолчанию стало на 20% шире;
- у переключателя «Основные/Все настройки» появился непрозрачный фон-плашка, чтобы содержимое под ним не просвечивало.

- _выравнивание иконки в менюбаре выделил в отдельный pr_

## Зачем

Текстовые области сохраняли ширину документа больше ширины scroll view, из-за чего строки обрезались и появлялось горизонтальное движение. Принудительный старый стиль скроллбара также игнорировал системную настройку macOS. Фон переключателя предотвращает визуальное наложение на элементы под ним.

Правка выравнивания значка и кода языка в строке меню вынесена в отдельный PR: она требует осторожного поведения на разных версиях macOS и дисплеях с вырезом.

## Проверка

- `git diff --check` проходит;
- изменённые Swift-файлы проходят parser validation;
- интерфейс вручную проверялся в локальной тестовой сборке;
- полный clean build недоступен из этого checkout, потому что игнорируемые сборки `vendor/whisper.cpp`, FluidAudio и Sparkle в него не входят.
